### PR TITLE
Refactor to be faster, more flexible and safer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ dependencies = [
  "byteorder 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "streaming-stats 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -168,6 +168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "persistent"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "plugin"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,20 +190,6 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "route-recognizer"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "router"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "iron 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["Marc Mailhot <mmm11105@gmail.com>"]
 byteorder = "0.5.1"
 streaming-stats = "0.1.27"
 iron = "0.3.0"
-router = "0.1.1"
 staticfile = "0.2.0"
 mount = "0.1.0"
+persistent = "0.1.0"

--- a/src/lib/btsf.rs
+++ b/src/lib/btsf.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::io::*;
 use std::str;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -18,36 +17,39 @@ pub struct CorrelatedTimeSeries<'a> {
     pub correlation: f32
 }
 
-pub fn read_btsf_file<T: Read + Seek>(f: &mut T) -> Vec<BinaryTimeSeries> {
-    f.seek(SeekFrom::Start(0)).unwrap();
+pub fn read_btsf_file<T: Read + Seek>(f: &mut T) -> Result<Vec<BinaryTimeSeries>> {
+    try!(f.seek(SeekFrom::Start(0)));
     let mut series = Vec::<BinaryTimeSeries>::new();
-    let version = f.read_u32::<LittleEndian>().unwrap();
-    let file_header_len = f.read_u32::<LittleEndian>().unwrap();
-    let rec_header_len = f.read_u32::<LittleEndian>().unwrap();
-    let num_records = f.read_u32::<LittleEndian>().unwrap();
+    let version = try!(f.read_u32::<LittleEndian>());
+    let file_header_len = try!(f.read_u32::<LittleEndian>());
+    let rec_header_len = try!(f.read_u32::<LittleEndian>());
+    let num_records = try!(f.read_u32::<LittleEndian>());
 
-    f.seek(SeekFrom::Start(file_header_len as u64)).unwrap();
+    try!(f.seek(SeekFrom::Start(file_header_len as u64)));
 
     println!("Version Number: {}", version);
     println!("File Header Len: {}", file_header_len);
     println!("Rec Header Len: {}", rec_header_len);
     println!("Num Records: {}", num_records);
 
-    for i in 0..num_records {
-        let n = f.read_u32::<LittleEndian>().unwrap();
-        let name_length = f.read_u32::<LittleEndian>().unwrap();
-        f.seek(SeekFrom::Current((rec_header_len - 8) as i64)).unwrap(); // Skip padding bytes;
+    for _ in 0..num_records {
+        let n = try!(f.read_u32::<LittleEndian>());
+        let name_length = try!(f.read_u32::<LittleEndian>());
+        try!(f.seek(SeekFrom::Current((rec_header_len - 8) as i64))); // Skip padding bytes;
 
         let mut buffer = [0; 1024];
-        f.take(name_length as u64).read(&mut buffer).unwrap();
+        try!(f.take(name_length as u64).read(&mut buffer));
 
-        let name = str::from_utf8(&buffer[0..(name_length as usize)]).unwrap();
+        let name = match str::from_utf8(&buffer[0..(name_length as usize)]) {
+            Ok(s) => s,
+            Err(_) => return Err(Error::new(ErrorKind::InvalidInput, "Invalid input UTF-8")),
+        };
 
         let mut data = Vec::<Point>::new();
 
-        for j in 0..n {
-            let t = f.read_i32::<LittleEndian>().unwrap();
-            let d = f.read_f32::<LittleEndian>().unwrap();
+        for _ in 0..n {
+            let t = try!(f.read_i32::<LittleEndian>());
+            let d = try!(f.read_f32::<LittleEndian>());
             data.push(Point{t: t, val: d});
         }
         series.push(BinaryTimeSeries{
@@ -56,26 +58,27 @@ pub fn read_btsf_file<T: Read + Seek>(f: &mut T) -> Vec<BinaryTimeSeries> {
         })
     }
 
-    return series;
+    return Ok(series);
 }
 
-pub fn write_correlated_btsf_file<T: Write>(data: &[CorrelatedTimeSeries], output: &mut T){
+pub fn write_correlated_btsf_file<T: Write>(data: &[CorrelatedTimeSeries], output: &mut T) -> Result<()> {
     // Version Header, File Header Len, Rec Header Len
-    output.write_u32::<LittleEndian>(2).unwrap();
-    output.write_u32::<LittleEndian>(16).unwrap();
-    output.write_u32::<LittleEndian>(12).unwrap();
+    try!(output.write_u32::<LittleEndian>(2));
+    try!(output.write_u32::<LittleEndian>(16));
+    try!(output.write_u32::<LittleEndian>(12));
 
-    output.write_u32::<LittleEndian>(data.len() as u32);
+    try!(output.write_u32::<LittleEndian>(data.len() as u32));
 
     for corr_record in data {
         let record = corr_record.series;
-        output.write_u32::<LittleEndian>(record.data.len() as u32);
-        output.write_u32::<LittleEndian>(record.name.len() as u32);
-        output.write_f32::<LittleEndian>(corr_record.correlation as f32);
-        output.write(&record.name.as_bytes());
+        try!(output.write_u32::<LittleEndian>(record.data.len() as u32));
+        try!(output.write_u32::<LittleEndian>(record.name.len() as u32));
+        try!(output.write_f32::<LittleEndian>(corr_record.correlation as f32));
+        try!(output.write(&record.name.as_bytes()));
         for i in 0..record.data.len() {
-            output.write_i32::<LittleEndian>(record.data[i].t);
-            output.write_f32::<LittleEndian>(record.data[i].val);
+            try!(output.write_i32::<LittleEndian>(record.data[i].t));
+            try!(output.write_f32::<LittleEndian>(record.data[i].val));
         }
     }
+    Ok(())
 }

--- a/src/lib/correlate.rs
+++ b/src/lib/correlate.rs
@@ -2,17 +2,21 @@ use lib::btsf::*;
 use lib::stats::*;
 use std::fs::File;
 
-pub fn correlate(data: &BinaryTimeSeries) -> Vec<BinaryTimeSeries>{
-    let mut possibilities = read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+pub fn correlate<'a>(data: &BinaryTimeSeries, possibilities: &'a [BinaryTimeSeries]) -> Vec<CorrelatedTimeSeries<'a>>{
+    // let mut possibilities = read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+    let mut correlations = Vec::new();
 
-    for i in 0..possibilities.len() {
-        let (xs, ys) = pairinate(&possibilities[i], &data);
-        possibilities[i].correlation = pearson_correlation_coefficient(&xs, &ys) as f32;
+    for poss in possibilities {
+        let (xs, ys) = pairinate(poss, &data);
+        correlations.push(CorrelatedTimeSeries{
+          series: poss,
+          correlation: pearson_correlation_coefficient(&xs, &ys) as f32
+        });
     }
 
-    possibilities.sort_by(|btsa, btsb| btsb.correlation.partial_cmp(&btsa.correlation).unwrap());
+    correlations.sort_by(|btsa, btsb| btsb.correlation.partial_cmp(&btsa.correlation).unwrap());
 
-    println!("{}", possibilities[0].correlation);
+    println!("{}", correlations[0].correlation);
 
-    return possibilities;
+    return correlations;
 }

--- a/src/lib/correlate.rs
+++ b/src/lib/correlate.rs
@@ -1,6 +1,5 @@
 use lib::btsf::*;
 use lib::stats::*;
-use std::fs::File;
 
 pub fn correlate<'a>(data: &BinaryTimeSeries, possibilities: &'a [BinaryTimeSeries]) -> Vec<CorrelatedTimeSeries<'a>>{
     // let mut possibilities = read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());

--- a/src/lib/stats.rs
+++ b/src/lib/stats.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use lib::btsf::*;
 use stats;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,26 @@
 extern crate byteorder;
 extern crate stats;
 extern crate iron;
-#[macro_use]
-extern crate router;
 extern crate staticfile;
 extern crate mount;
+extern crate persistent;
 mod lib;
 
 use std::fs::File;
 use std::io::*;
 use std::iter::FromIterator;
-use iron::{Iron, Request, Response, IronResult};
+use iron::{Iron, Request, Response, IronResult, Plugin};
+use iron::typemap::Key;
 use iron::status;
 use iron::headers;
 use iron::mime::Mime;
-use router::{Router};
 use mount::Mount;
 use staticfile::Static;
 use std::path::Path;
+
+#[derive(Copy, Clone)]
+pub struct DataSets;
+impl Key for DataSets { type Value = Vec<lib::btsf::BinaryTimeSeries>; }
 
 fn main() {
     fn request_handler(req: &mut Request) -> IronResult<Response>{
@@ -28,7 +31,7 @@ fn main() {
             return Ok(Response::with((status::BadRequest, "Please send a BTSF file with precisely one chart in it")))
         }
 
-        let data_sets = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+        let data_sets = req.get::<persistent::Read<DataSets>>().unwrap();
         let result = lib::correlate::correlate(&input_charts[0], &data_sets[..]);
 
         let mut response_data: Vec<u8> = Vec::new();
@@ -43,5 +46,9 @@ fn main() {
         .mount("/", Static::new(Path::new("./public")))
         .mount("/find", request_handler);
 
-    Iron::new(mount).http("localhost:8080").unwrap();
+    let data_sets = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+    let mut chain = iron::Chain::new(mount);
+    chain.link_before(persistent::Read::<DataSets>::one(data_sets));
+
+    Iron::new(chain).http("localhost:8080").unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,12 @@ fn main() {
         if input_charts.len() != 1 {
             return Ok(Response::with((status::BadRequest, "Please send a BTSF file with precisely one chart in it")))
         }
-        let result = lib::correlate::correlate(&input_charts[0]);
-        
+
+        let data_sets = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+        let result = lib::correlate::correlate(&input_charts[0], &data_sets[..]);
+
         let mut response_data: Vec<u8> = Vec::new();
-        lib::btsf::write_btsf_file(&result, &mut response_data);
+        lib::btsf::write_correlated_btsf_file(&result[..], &mut response_data);
 
         let contentType: Mime = "application/octet-stream".parse().unwrap();
         return Ok(Response::with((status::Ok, contentType, response_data)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,9 @@ mod lib;
 
 use std::fs::File;
 use std::io::*;
-use std::iter::FromIterator;
-use iron::{Iron, Request, Response, IronResult, Plugin};
+use iron::{Iron, Request, Response, IronResult, IronError, Plugin};
 use iron::typemap::Key;
 use iron::status;
-use iron::headers;
 use iron::mime::Mime;
 use mount::Mount;
 use staticfile::Static;
@@ -25,8 +23,11 @@ impl Key for DataSets { type Value = Vec<lib::btsf::BinaryTimeSeries>; }
 fn main() {
     fn request_handler(req: &mut Request) -> IronResult<Response>{
         let mut buffer: Vec<u8> = Vec::new();
-        req.body.read_to_end(&mut buffer);
-        let input_charts = lib::btsf::read_btsf_file(&mut Cursor::new(&mut buffer));
+        req.body.read_to_end(&mut buffer).unwrap();
+        let input_charts = match lib::btsf::read_btsf_file(&mut Cursor::new(&mut buffer)) {
+            Ok(charts) => charts,
+            Err(e) => return Err(IronError::new(e, status::BadRequest)),
+        };
         if input_charts.len() != 1 {
             return Ok(Response::with((status::BadRequest, "Please send a BTSF file with precisely one chart in it")))
         }
@@ -35,10 +36,12 @@ fn main() {
         let result = lib::correlate::correlate(&input_charts[0], &data_sets[..]);
 
         let mut response_data: Vec<u8> = Vec::new();
-        lib::btsf::write_correlated_btsf_file(&result[..], &mut response_data);
+        if let Err(e) = lib::btsf::write_correlated_btsf_file(&result[..], &mut response_data) {
+            return Err(IronError::new(e, status::InternalServerError));
+        }
 
-        let contentType: Mime = "application/octet-stream".parse().unwrap();
-        return Ok(Response::with((status::Ok, contentType, response_data)));
+        let content_type: Mime = "application/octet-stream".parse().unwrap();
+        return Ok(Response::with((status::Ok, content_type, response_data)));
     };
 
     let mut mount = Mount::new();
@@ -46,7 +49,7 @@ fn main() {
         .mount("/", Static::new(Path::new("./public")))
         .mount("/find", request_handler);
 
-    let data_sets = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap());
+    let data_sets = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap()).unwrap();
     let mut chain = iron::Chain::new(mount);
     chain.link_before(persistent::Read::<DataSets>::one(data_sets));
 


### PR DESCRIPTION
- Splits the correlation result data structure from the input data
- Only loads the data sets once at server startup
- Uses `try!` to avoid crashing the server if someone sends a bad request

@mmailhot 
