### PR TITLE
Load multiple data sets at startup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,9 @@
       font-family: 'PT Sans';
       background: #fff;
     }
-   .graph h4 {
-       box-sizing: border-box;
+
+    .graph h4 {
+      box-sizing: border-box;
       font-family: sans-serif;
       font-size: 12pt;
       margin: 0px;
@@ -32,8 +33,8 @@
     .graphs {
       display: flex;
       flex-wrap: wrap;
-        justify-content: center;
-        color: #FFF;
+      justify-content: center;
+      color: #FFF;
     }
 
     .graph {
@@ -43,42 +44,43 @@
       flex-direction: column;
       background: #2196F3;
       justify-content: space-between;
-         box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+      box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
     }
 
     .graph img {
-        box-sizing: border-box;
-        position: absolute;
-        bottom: 10px;
-        right: 10px;
-        width: 50px;
-        height: 50px;
-        padding: 10px;
-        border-radius: 25px;
+      box-sizing: border-box;
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      width: 50px;
+      height: 50px;
+      padding: 10px;
+      border-radius: 25px;
       background: #42A5F5;
-        box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
-        transition: all 0.5s;
+      box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+      transition: all 0.5s;
     }
 
     .graph img:hover{
-       box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+      box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
     }
 
-   .graph img:active{
-         box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
-        transition: all 0.2s;
-   }
+    .graph img:active{
+      box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+      transition: all 0.2s;
+    }
 
    .graph .correlation {
-       position: absolute;
-       color: #555;
-       bottom: 10px;
-       left: 10px;
-       padding: 5px;
-       font-size: 10pt;
-       border-radius: 3px;
-       background-color: #eee;
-   }
+      position: absolute;
+      color: #555;
+      bottom: 10px;
+      left: 10px;
+      padding: 5px;
+      font-size: 10pt;
+      border-radius: 3px;
+      background-color: #eee;
+    }
+
     .container {
       display: flex;
       flex-direction: column;
@@ -95,8 +97,8 @@
       border: 0;
       webkit-box-shadow: none;
       box-shadow: none;
-        font-size: 24px;
-        color: #555;
+      font-size: 24px;
+      color: #555;
       border-bottom: 3px solid #555;
     }
 
@@ -104,11 +106,19 @@
       margin-top: 7px;
     }
 
-   .btsf-attribution {
-       position: absolute;
-       top: 40px;
-       left: 40px;
-   }
+    .controls > * {
+      padding: 5px 20px;
+    }
+
+    .button-link {
+      color: #42A5F5;
+    }
+
+    .btsf-attribution {
+      position: absolute;
+      top: 40px;
+      left: 40px;
+    }
   </style>
 </head>
 <body onload="init()">
@@ -120,6 +130,7 @@
         </header>
     <div class="controls">
         <label><input type="checkbox" id="zeroYAxis" onchange="redisplay();" checked> Include zero in Y axis</label>
+        <a href="javascript:clearCorr()" id="clearCorrButton" class="button-link" style="display: none;">clear correlation query</a>
     </div>
         <div id="graphs" class="graphs">
     </div>

--- a/public/script/main.js
+++ b/public/script/main.js
@@ -252,6 +252,11 @@ function setNumberOfGraphs(n) {
 
 function redisplay() {
   normalizeYAxis = !document.getElementById("zeroYAxis").checked;
+  if(reqCorrelationQuery !== null) {
+    document.getElementById("clearCorrButton").style.display = "inline";
+  } else {
+    document.getElementById("clearCorrButton").style.display = "none";
+  }
   displayRecords(curRecords, 100);
 }
 
@@ -273,6 +278,12 @@ function filterGraphs() {
   var filter = document.getElementById("filter-box").value;
   if(filter === reqFilter) return;
   reqFilter = filter;
+  updateFromServer();
+}
+
+function clearCorr() {
+  reqCorrelationQuery = null;
+  curOverlay = null;
   updateFromServer();
 }
 

--- a/public/script/main.js
+++ b/public/script/main.js
@@ -286,6 +286,10 @@ function handleNewData(oEvent) {
   } else {
     console.log("Couldn't fetch file " + url);
   }
+
+  // TODO: maybe instead of cancelling in flight requests when new ones are sent out
+  // perhaps we can just always prefer results from requests that were *sent* more recently
+  // even if they arrive earlier due to weird networking things.
   inFlightRequest = null;
 }
 

--- a/src/lib/btsf.rs
+++ b/src/lib/btsf.rs
@@ -3,7 +3,7 @@ use std::str;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp::Ordering;
 
-#[derive(PartialEq, PartialOrd, Clone)]
+#[derive(PartialEq, PartialOrd, Clone, Debug)]
 pub struct Point {
     pub t: i32,
     pub val: f32
@@ -15,7 +15,7 @@ impl Ord for Point {
     }
 }
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Clone)]
+#[derive(PartialEq, PartialOrd, Eq, Ord, Clone, Debug)]
 pub struct BinaryTimeSeries {
     pub name: String,
     pub data: Vec<Point>

--- a/src/lib/stats.rs
+++ b/src/lib/stats.rs
@@ -62,8 +62,8 @@ fn get_start_index(series: &BinaryTimeSeries, target: &BinaryTimeSeries) -> Opti
 fn get_end_index(series: &BinaryTimeSeries, target: &BinaryTimeSeries) -> Option<usize>{
     let mut end_index = series.data.len() - 1;
 
-    while series.data[end_index].t < target.data[target.data.len() - 1].t{
-        if end_index == 0{
+    while series.data[end_index].t > target.data[target.data.len() - 1].t{
+        if end_index == 0 {
             return None;
         }
         end_index -= 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,10 @@ impl Key for CorrCache { type Value = CorrelationCache; }
 
 lazy_static! {
     static ref DATA_SETS: Vec<lib::btsf::BinaryTimeSeries> = {
-        lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap()).unwrap()
+        let mut all_data = lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap()).unwrap();
+        let file_2 = lib::btsf::read_btsf_file(&mut File::open("./btsf/canada_gdp.btsf").unwrap()).unwrap();
+        all_data.extend_from_slice(&file_2[..]); // Note: this does a copy, could be more efficient but we only do it at startup
+        all_data
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use mount::Mount;
 use staticfile::Static;
 use std::path::Path;
 use lib::caching::CorrelationCache;
+use std::ascii::AsciiExt;
 
 const PER_PAGE : usize = 100;
 
@@ -53,8 +54,8 @@ fn main() {
             cache.correlate(&input_charts[0], &DATA_SETS[..])
         };
 
-        let filter : &str = req.url.query.as_ref().map(|x| &**x).unwrap_or("");
-        let filtered : Vec<lib::btsf::CorrelatedTimeSeries> = result.into_iter().filter(|s| s.series.name.contains(filter)).take(PER_PAGE).collect();
+        let filter : String = req.url.query.as_ref().map(|x| &**x).unwrap_or("").to_ascii_lowercase();
+        let filtered : Vec<lib::btsf::CorrelatedTimeSeries> = result.into_iter().filter(|s| s.series.name.to_ascii_lowercase().contains(&filter)).take(PER_PAGE).collect();
 
         let mut response_data: Vec<u8> = Vec::new();
         if let Err(e) = lib::btsf::write_correlated_btsf_file(&filtered[..], &mut response_data) {
@@ -66,8 +67,8 @@ fn main() {
     };
 
     fn raw_handler(req: &mut Request) -> IronResult<Response>{
-        let filter : &str = req.url.query.as_ref().map(|x| &**x).unwrap_or("");
-        let result: Vec<&lib::btsf::BinaryTimeSeries> = DATA_SETS.iter().filter(|s| s.name.contains(filter)).take(PER_PAGE).collect();
+        let filter : String = req.url.query.as_ref().map(|x| &**x).unwrap_or("").to_ascii_lowercase();
+        let result: Vec<&lib::btsf::BinaryTimeSeries> = DATA_SETS.iter().filter(|s| s.name.to_ascii_lowercase().contains(&filter)).take(PER_PAGE).collect();
 
         let mut response_data: Vec<u8> = Vec::new();
         if let Err(e) = lib::btsf::write_btsf_file(&result[..], &mut response_data) {


### PR DESCRIPTION
This loads both data sets at startup instead of just mortality.

~~However, when I try and find correlations for a deaths data set I only get correlations with other deaths data sets and when I try and find correlations with a GDP data set I don’t get any correlations to deaths data sets.~~ (I fixed this, it was a `<` that should have been a `>`)

The following must be done:
- [x] Fix correlation so it works between the sets (probably an overlap finder bug)
- [x] Add a button to clear the correlation selection so that you can search for data sets that don’t overlap again.

![screen shot 2016-04-13 at 8 23 38 pm](https://cloud.githubusercontent.com/assets/887610/14513420/aa2b3fec-01b5-11e6-99cb-310e46b21268.png)

@mmailhot 
