### PR TITLE
Script to crunch down enormous data sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 data/
 btsf/fred.btsf
+btsf/fred-small.btsf

--- a/scripts/crunch.rb
+++ b/scripts/crunch.rb
@@ -1,0 +1,45 @@
+require "progress"
+
+input_path = ARGV[0] || "btsf/fred.btsf"
+output_path = ARGV[1] || "btsf/fred-small.btsf"
+input = File.open(input_path,"r")
+output = File.open(output_path,"w")
+
+# Read Header
+version, file_header_size, rec_header_size, num_records = input.read(4*4).unpack("L*")
+input.seek(file_header_size - 4*4, :CUR)
+
+# Write Header
+output.print [version, file_header_size, rec_header_size, num_records].pack("L*")
+
+num_records.times.with_progress do
+  # Read record header
+  num_points, name_length = input.read(2*4).unpack('L*'.freeze)
+  input.seek(rec_header_size - 2*4, :CUR)
+
+  # Read record data
+  name = input.read(name_length)
+  points = num_points.times.map do
+    input.read(2*4).unpack("le")
+  end
+
+  # Filter points
+  last_time = nil
+  points.reject! do |d,v|
+    time = Time.at(d)
+    toss = last_time && (time.month == last_time.month && time.year == last_time.year)
+    last_time = time unless toss
+    toss
+  end
+
+  # Write record data
+  output.print [points.length, name_length].pack("L*")
+  output.print name
+  points.each do |d,v|
+    output.print [d, v].pack("le")
+  end
+end
+
+# Data
+# data.each do |name, points|
+# end

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ lazy_static! {
         let mut all_data = Vec::new();
         lib::btsf::read_btsf_file(&mut File::open("./btsf/mortality.btsf").unwrap(), &mut all_data).unwrap();
         lib::btsf::read_btsf_file(&mut File::open("./btsf/canada_gdp.btsf").unwrap(), &mut all_data).unwrap();
-        if Path::new("./btsf/fred.btsf").exists() {
-            lib::btsf::read_btsf_file(&mut BufReader::new(File::open("./btsf/fred.btsf").unwrap()), &mut all_data).unwrap();
+        if Path::new("./btsf/fred-small.btsf").exists() {
+            lib::btsf::read_btsf_file(&mut BufReader::new(File::open("./btsf/fred-small.btsf").unwrap()), &mut all_data).unwrap();
         }
         all_data
     };


### PR DESCRIPTION
Trims down all data sets to at most monthly. This solves the problem of daily series like all the London ones causing multiple problems:
- They cause the graphing code to draw way too many points
- They are sent over the network in their entirety causing filtering for "london" to return a results set that is way too large for live filtering (around 1 megabyte).
- They are slower to correlate against

And we just don't need that much accuracy yet. If we ever improve our ability to deal with it we can switch back to the full size FRED btsf file.

It only gets a little bit smaller in file size though:

```
$ ls -lh btsf
total 1452352
-rw-r--r--  1 tristan  staff   423K 10 Apr 22:27 canada_gdp.btsf
-rw-r--r--  1 tristan  staff   325M 20 Apr 16:58 fred-small.btsf
-rw-r--r--  1 tristan  staff   382M 14 Apr 16:13 fred.btsf
-rw-r--r--  1 tristan  staff   1.1M 28 Mar 20:00 mortality.btsf
```

@mmailhot 
